### PR TITLE
disable timeout mechanism

### DIFF
--- a/templates/restic.service.j2
+++ b/templates/restic.service.j2
@@ -4,5 +4,5 @@ Description=Backup {{ item.name }} using restic
 [Service]
 Type=oneshot
 ExecStart={{ restic_script_dir }}/backup-{{ item.name }}.sh
-TimeoutStartSec=900s
+TimeoutStartSec=0
 Environment="CRON=true"


### PR DESCRIPTION
**TimeoutStartSec=**
   + When a service doesn't signal start-up completion within TimeoutStartSec, systemd considers the service failed;
   + for long-running shell scripts it is essential to modify TimeoutStartSec or disable the timeout logic altogether 
		   as above, with ``TimeoutStartSec=0``. See man systemd.service for more details.