### PR TITLE
fix: defaults: Match restic_install_path value to docs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 restic_url: '{{ restic_url_default }}'
 restic_version: '0.12.1'
 restic_download_path: '/opt/restic'
-restic_install_path: '/usr/bin'
+restic_install_path: '/usr/local/bin'
 restic_script_dir: '/opt/restic'
 restic_log_dir: '{{ restic_script_dir }}/log'
 restic_repos: {}


### PR DESCRIPTION
The README (Role Variables) asserts that `restic_install_path`
defaults to `/usr/local/bin`, when in fact it defaults to
`/usr/bin`. Fix the defaults to match the documentation.

Signed-off-by: Martin Kennedy <hurricos@gmail.com>