### PR TITLE
Fix exclude-caches directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ the `exclude` key on a backup allows you to specify multiple files to exclude or
 files to look for filenames to be excluded. You can specify the following keys:
 ```yaml
 exclude:
-    exclude_cache: true
+    exclude_caches: true
     exclude:
         - /path/to/file
     iexclude:

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -109,8 +109,8 @@ set -uxo pipefail
 {%- endmacro %}
 
 {% macro exclude(exclude) %}
-    {% if exclude.exclude_cache is defined and exclude.exclude_cache == true %}
-        --exclude-cache \
+    {% if exclude.exclude_caches is defined and exclude.exclude_caches == true %}
+        --exclude-caches \
     {% endif %}
     {% if exclude.exclude is defined %}
         {% for path in exclude.exclude %}


### PR DESCRIPTION
It's called --exclude-caches, not --exclude-cache
see https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files