### PR TITLE
README: fix repo name typo in backup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ Example:
 restic_backups:
   data:
     name: data
-    repo: remove
+    repo: remote
     src: /path/to/data
     scheduled: true
     schedule_oncalendar: '*-*-* 01:00:00'
   database:
     name: database
-    repo: remove
+    repo: remote
     stdin: true
     stdin_cmd: pg_dump -Ubackup db_name
     stdin_filename: db_name_dump.sql


### PR DESCRIPTION
change the repo name from 'remove' to 'remote' to match the name used in the 'restic_repos' configuration example above.