### PR TITLE
Properly respect restic_do_not_cleanup_cron

### DIFF
--- a/tasks/schedule.yml
+++ b/tasks/schedule.yml
@@ -15,7 +15,7 @@
 
 - name: (SCHEDULE) delete old cron entry from previous versions of this role
   ansible.builtin.include_tasks: delete_legacy_cron_entry.yml
-  when: restic_do_not_cleanup_cron | bool
+  when: not restic_do_not_cleanup_cron | bool
 
 - name: (SCHEDULE) install restic via cronjob
   ansible.builtin.include_tasks: restic_create_cron.yml
@@ -30,3 +30,4 @@
     - ansible_service_mgr == 'systemd'
     - not restic_force_cron | default(false)
     - restic_schedule_type != "cronjob"
+    - not restic_do_not_cleanup_cron | bool


### PR DESCRIPTION
When setting `restic_do_not_cleanup_cron`, this role still tries to remove (old) cron enties: 
This PR fixes it.
Btw, in general I advise to not use negations in variable names, because you need an addition hop to parse the logic behind it, especially if the variable is negated another time, i.e.

```
when: not restic_do_not_cleanup_cron | bool
```

This would be much nicer:

```
when: restic_cleanup_cron | bool
```