### PR TITLE
bugfix: Need to wrap Azure SAS tokens in quotes

### DIFF
--- a/templates/restic_access_Linux.j2
+++ b/templates/restic_access_Linux.j2
@@ -21,7 +21,7 @@ export AZURE_ACCOUNT_NAME={{ restic_repos[item.repo].azure_account_name }}
 export AZURE_ACCOUNT_KEY={{ restic_repos[item.repo].azure_account_key }}
 {% endif %}
 {% if restic_repos[item.repo].azure_account_sas is defined %}
-export AZURE_ACCOUNT_SAS={{ restic_repos[item.repo].azure_account_sas }}
+export AZURE_ACCOUNT_SAS='{{ restic_repos[item.repo].azure_account_sas }}'
 {% endif %}
 {% if restic_repos[item.repo].azure_endpoint_suffix is defined %}
 export AZURE_ENDPOINT_SUFFIX={{ restic_repos[item.repo].azure_endpoint_suffix }}

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -64,7 +64,7 @@ export AZURE_ACCOUNT_NAME={{ restic_repos[item.repo].azure_account_name }}
 export AZURE_ACCOUNT_KEY={{ restic_repos[item.repo].azure_account_key }}
 {% endif %}
 {% if restic_repos[item.repo].azure_account_sas is defined %}
-export AZURE_ACCOUNT_SAS={{ restic_repos[item.repo].azure_account_sas }}
+export AZURE_ACCOUNT_SAS='{{ restic_repos[item.repo].azure_account_sas }}'
 {% endif %}
 {% if restic_repos[item.repo].azure_endpoint_suffix is defined %}
 export AZURE_ENDPOINT_SUFFIX={{ restic_repos[item.repo].azure_endpoint_suffix }}


### PR DESCRIPTION
Doing some testing with the new Azure support, I found a bug with the template files.  The SAS token contains =s which make bash upset.
This appears to fix it - have tested by manually editing the scripts and re-running