### PR TITLE
added pre_backup_cmd to backup items (wip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Available variables:
 | `stdin`            |              no               | Is this backup created from a [stdin](https://restic.readthedocs.io/en/stable/040_backup.html#reading-data-from-stdin)? |
 | `stdin_cmd`        | no (yes if `stdin` == `true`) | The command to produce the stdin. |
 | `stdin_filename`   |              no               | The filename used in the repository. |
+| `pre_backup_cmd`   |              no               | A command to run before backup, typically used to dump databases to disk |
 | `tags`             |              no               | Array of default tags  |
 | `keep_last`        |              no               | If set, only keeps the last n snapshots.  |
 | `keep_hourly`      |              no               | If set, only keeps the last n hourly snapshots.                                                                                                                              |
@@ -197,6 +198,13 @@ restic_backups:
     stdin_filename: db_name_dump.sql
     scheduled: true
     schedule_oncalendar: '*-*-* 01:30:00'
+  all_databases:
+    name: all_databases
+    repo: remote
+    src: /var/dumped_data
+    scheduled: true
+    schedule_oncalendar: '*-*-* 02:00:00'
+    pre_backup_cmd: cd /var/dumped_data && mariadb -N -e 'show databases' | while read dbname; do mariadb-dump --complete-insert --routines --triggers --single-transaction "$dbname" > "$dbname".sql; done
 ```
 
 > You can also specify restic_backups as an array, which is a legacy feature and

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -24,15 +24,18 @@ fi
 
 
 {% if item.disable_logging is defined and item.disable_logging %}
+{% set pre_backup_cmd_result_log, pre_backup_cmd_output_log = "/dev/null", "/dev/null" %}
 {% set backup_result_log, backup_output_log = "/dev/null", "/dev/null" %}
 {% set forget_result_log, forget_output_log = "/dev/null", "/dev/null" %}
 {% else %}
 {% if (item.log_to_journald is defined and item.log_to_journald) %}
+{% set pre_backup_cmd_result_log, pre_backup_cmd_output_log = "| systemd-cat -t " + item.name, "2>&1 | systemd-cat -t " + item.name %}
 {% set backup_result_log, backup_output_log = "| systemd-cat -t " + item.name, "2>&1 | systemd-cat -t " + item.name %}
 {% set forget_result_log, forget_output_log = "| systemd-cat -t " + item.name, "2>&1 | systemd-cat -t " + item.name %}
 {% else %}
-{% set backup_result_log, backup_output_log = ">> " + restic_log_dir + "/" + item.name + "-backup-result.log", " 2>&1 | tee " + restic_log_dir + "/" + item.name + "-backup-output.log" %}
-{% set forget_result_log, forget_output_log = ">> " + restic_log_dir + "/" + item.name + "-forget-result.log", " 2>&1 | tee " + restic_log_dir + "/" + item.name + "-forget-output.log" %}
+{% set pre_backup_cmd_result_log, pre_backup_cmd_output_log = ">> " + restic_log_dir + "/" + item.name + "-pre_backup_cmd-result.log", "| tee " + restic_log_dir + "/" + item.name + "-pre_backup_cmd-output.log" %}
+{% set backup_result_log, backup_output_log = ">> " + restic_log_dir + "/" + item.name + "-backup-result.log", "| tee " + restic_log_dir + "/" + item.name + "-backup-output.log" %}
+{% set forget_result_log, forget_output_log = ">> " + restic_log_dir + "/" + item.name + "-forget-result.log", "| tee " + restic_log_dir + "/" + item.name + "-forget-output.log" %}
 {% endif %}
 {% endif %}
 
@@ -224,6 +227,26 @@ set -uxo pipefail
         {% endfor %}
     {% endif %}
 {% endmacro %}
+
+
+{% if item.pre_backup_cmd is defined %}
+  {{ item.pre_backup_cmd }} {{ pre_backup_cmd_output_log }}
+if [[ $? -eq 0 ]]
+then
+    echo "$(date -u '+%Y-%m-%d %H:%M:%S') OK" {{ pre_backup_cmd_result_log }}
+else
+    echo "$(date -u '+%Y-%m-%d %H:%M:%S') ERROR" {{ pre_backup_cmd_result_log }}
+    {% if item.mail_on_error is defined and item.mail_on_error == true %}
+    mail -s "restic backup failed on {{ ansible_hostname }}" {{ item.mail_address }}  <<< "Something went wrong while running restic backup script running at {{ ansible_hostname }} at $(date -u '+%Y-%m-%d %H:%M:%S').
+      {%- if item.src is defined -%}
+        {{ ' ' }}We tried to backup '{{ item.src }}'.
+      {%- endif -%}
+      {{ ' ' }}Please repair the restic-{{ item.name | replace(' ', '') }} job."
+    {% endif %}
+fi
+{% endif %}
+
+
 {#
   Define backup commands
 #}


### PR DESCRIPTION
Opening this PR as I did this change locally and thought it would add value to the role.

I have a changing number of databases I need to backup that need to be dumped to file before each backup. Since the names and numbers are not known at playbook-runtime I cannot use the stdin-feature in this role. My solution is a `pre_backup_cmd`.

Let me know if this is interesting. I am open to refining the change as needed.