### PR TITLE
added new variable restic_backup_script_shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ ansible-galaxy install roles-ansible.restic
 | `restic_download_path`        | `'/opt/restic'`                 | Download location for the restic binary                                                                                                              |
 | `restic_install_path`         | `'/usr/local/bin'`              | Install location for the restic binary                                                                                                               |
 | `restic_script_dir`           | `'/opt/restic'`                 | Location of the generated backup scripts                                                                                                             |
+| `restic_backup_script_shell`  | `sh`                            | Shell to use for run of backup script                                                                                                             |
 | `restic_log_dir`              | `'{{ restic_script_dir }}/log'` | Location of the logs of the backup scripts                                                                                                           |
 | `restic_repos`                | `{}`                            | A dictionary of repositories where snapshots are stored. *(More Info: [Repos](#Repos))*                                                              |
 | `restic_backups`              | `{}` (or `[]`)                  | A list of dictionaries specifying the files and directories to be backed up *(More Infos: [Backups](#Backups))*                                      |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ restic_version: '0.16.3'
 restic_download_path: '/opt/restic'
 restic_install_path: '/usr/local/bin'
 restic_script_dir: '/opt/restic'
+restic_backup_script_shell: sh
 restic_log_dir: '{{ restic_script_dir }}/log'
 restic_repos: {}
 restic_backups: []

--- a/tasks/run_backup.yml
+++ b/tasks/run_backup.yml
@@ -1,7 +1,7 @@
 ---
 - name: (RUN BACKUP) Run backup script
   ansible.builtin.command:
-    cmd: "/usr/bin/env sh {{ restic_script_dir }}/backup-{{ item.name | replace(' ', '') }}.sh"
+    cmd: "/usr/bin/env {{ restic_backup_script_shell }} {{ restic_script_dir }}/backup-{{ item.name | replace(' ', '') }}.sh"
   no_log: "{{ restic_no_log }}"
   with_items: '{{ restic_backups }}'
   when:


### PR DESCRIPTION
Hi, 

I added a new variable called restic_backup_script_shell. With this variable it is possible to change the shell in `tasks/run_backup.yml`.

We need to configure bash because on our system we get the following error: 

```
user@backup_host:~# cat /etc/*ease
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

user@backup_host:~# /usr/bin/env sh /opt/restic/backup-myrepo.sh
trap: SIGSEGV: bad trap
trap: SIGINT: bad trap
/opt/restic/backup-vaultwarden.sh: 28: set: Illegal option -o pipefail
```