### PR TITLE
deps: Remove jmespath requirement with native solution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ There are multiple ways to install the role. Either clone or download it directl
 ansible-galaxy install roles-ansible.restic
 ```
 ## Requirements
+
 * bzip2
-* jmespath
 
 ## Role Variables
 

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -1,7 +1,7 @@
 ---
 - name: (BACKUP) reformat dict if necessary
   ansible.builtin.set_fact:
-    restic_backups: "{{ restic_backups | dict2items | json_query('[*].value') }}"
+    restic_backups: "{{ restic_backups | default([]) | map('extract', restic_backups) | list }}"
   when:
     - restic_backups | type_debug == "dict"
 


### PR DESCRIPTION
Issue: #121

## QA Log

I created a playbook which demonstrated that the same result was produced before and after the change:

```yaml
---
- name: backup your homefolders to /mnt/backup everyday night
  hosts: localhost
  #roles:
  #  - {role: ./, tags: restic}
  vars:
    restic_create_schedule: true
    restic_repos:
      local:
        location: '/mnt/backup'
        password: 'ChangM3'
        init: true

  tasks:
    - name: "Debug jmespath"
      tags: debug
      vars:
        restic_backups:
          top-level:
             keep_daily: 7
             keep_weeky: 4
          mop-level:
             keep_daily: 7
             keep_weeky: 4
      tags: debug
      debug:
        msg: "{{ restic_backups | dict2items | json_query('[*].value') }}"

    - name: "Debug Proposed"
      tags: debug
      vars:
        restic_backups:
          top-level:
             keep_daily: 7
             keep_weeky: 4
          mop-level:
             keep_daily: 7
             keep_weeky: 4
      tags: debug
      debug:
        msg: "{{ restic_backups | default([]) | map('extract', restic_backups) | list }}"
```
