### PR TITLE
Add support for passing in extra args to the `restic forget` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Available variables:
 | `keep_within`      |              no               | If set, only keeps snapshots in this time period.                                                                                                                            |
 | `keep_tag`         |              no               | If set, keep snapshots with this tags. Make sure to specify a list.                                                                                                          |
 | `prune`            |         no (`false`)          | If `true`, the `restic forget` command in the script has the [`--prune` option](https://restic.readthedocs.io/en/stable/060_forget.html#removing-backup-snapshots) appended. |
+| `forget_extra_args` |       no                     | Extra arguments to pass to the `restic forget` command. |
 | `scheduled`        |         no (`false`)          | If `restic_create_schedule` is set to `true`, this backup is scheduled and tries to create a systemd timer unit. If it fails, it is creating a cronjob. |
 | `schedule_oncalendar` |  ``'*-*-* 02:00:00'``      | The time for the systemd timer. Please notice the randomDelaySec option. By Default the backup is done every night at 2 am (+0-4h). But only if scheduled is true.  |
 | `schedule_minute`  |           no (`*`)            | Minute when the job is run. ( 0-59, *, */2, etc ) |

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -302,7 +302,7 @@ esac
 {#
   Define stdin forget commands
 #}
-{{ restic_install_path }}/restic forget {{ paths(item) }} {{ retention_pattern(item) }} {% if item.prune is defined and item.prune == true %}--prune{% endif %} {{ forget_output_log }}
+{{ restic_install_path }}/restic forget {{ paths(item) }} {{ retention_pattern(item) }} {% if item.prune is defined and item.prune == true %}--prune{% endif %} {% if item.forget_extra_args is defined %}{{ item.forget_extra_args }}{% endif %} {{ forget_output_log }}
 if [[ $? -eq 0 ]]
 then
     echo "$(date -u '+%Y-%m-%d %H:%M:%S') OK" {{ forget_result_log }}


### PR DESCRIPTION
Add support for passing in whatever extra args you'd like when tidying up old backups via `restic forget`.

My particular use-case is setting `--group-by host` so it clears up my snapshots properly.  While I could add support for that specific arg, this feels a lot more extensible (without adding lots of complexity).