### PR TITLE
feat: add GCP support

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,9 +1,9 @@
 ---
 - name: (CONF)Initialize repository
-  ansible.builtin.command: '{{ restic_install_path }}/restic init'
+  ansible.builtin.command: "{{ restic_install_path }}/restic init"
   environment:
-    RESTIC_REPOSITORY: '{{ item.value.location }}'
-    RESTIC_PASSWORD: '{{ item.value.password }}'
+    RESTIC_REPOSITORY: "{{ item.value.location }}"
+    RESTIC_PASSWORD: "{{ item.value.password }}"
     AWS_ACCESS_KEY_ID: '{{ item.value.aws_access_key | default("") }}'
     AWS_SECRET_ACCESS_KEY: '{{ item.value.aws_secret_access_key | default("") }}'
     AWS_DEFAULT_REGION: '{{ item.value.aws_default_region | default("") }}'
@@ -13,6 +13,9 @@
     AZURE_ENDPOINT_SUFFIX: '{{ item.value.azure_endpoint_suffix | default("") }}'
     B2_ACCOUNT_ID: '{{ item.value.b2_account_id | default("") }}'
     B2_ACCOUNT_KEY: '{{ item.value.b2_account_key | default("") }}'
+    GOOGLE_PROJECT_ID: '{{ item.value.google_project_id | default("") }}'
+    GOOGLE_APPLICATION_CREDENTIALS: '{{ item.value.google_application_credentials | default("") }}'
+    GOOGLE_ACCESS_TOKEN: '{{ item.value.google_access_token | default("") }}'
   no_log: "{{ restic_no_log }}"
   register: restic_init
   changed_when: "'created restic repository' in restic_init.stdout"


### PR DESCRIPTION
This pull request includes changes to the `tasks/configure.yml` file to improve the initialization of the repository and to add support for Google Cloud credentials.

Improvements to repository initialization:

* Changed the syntax for `ansible.builtin.command` and environment variables to use double quotes instead of single quotes for consistency.

Support for Google Cloud credentials:

* Added new environment variables `GOOGLE_PROJECT_ID`, `GOOGLE_APPLICATION_CREDENTIALS`, and `GOOGLE_ACCESS_TOKEN` to support Google Cloud storage.