### PR TITLE
feat: add missing GCP variables

### DIFF
--- a/templates/restic_access_Linux.j2
+++ b/templates/restic_access_Linux.j2
@@ -5,6 +5,12 @@
 
 export RESTIC_REPOSITORY={{ restic_repos[item.repo].location }}
 export RESTIC_PASSWORD='{{ restic_repos[item.repo].password | regex_replace('\'', '\'\\\'\'') }}'
+{% if restic_repos[item.repo].google_project_id is defined %}
+export GOOGLE_PROJECT_ID={{ restic_repos[item.repo].google_project_id }}
+{% endif %}
+{% if restic_repos[item.repo].google_application_credentials is defined %}
+export GOOGLE_APPLICATION_CREDENTIALS={{ restic_repos[item.repo].google_application_credentials }}
+{% endif %}
 {% if restic_repos[item.repo].aws_access_key is defined %}
 export AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
 {% endif %}

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -54,6 +54,12 @@ export GOMAXPROCS={{ restic__max_cpus }}
 export RESTIC_REPOSITORY={{ restic_repos[item.repo].location }}
 export RESTIC_PASSWORD='{{ restic_repos[item.repo].password | regex_replace('\'', '\'\\\'\'') }}'
 BACKUP_NAME={{ item.name }}
+{% if restic_repos[item.repo].google_project_id is defined %}
+export GOOGLE_PROJECT_ID={{ restic_repos[item.repo].google_project_id }}
+{% endif %}
+{% if restic_repos[item.repo].google_application_credentials is defined %}
+export GOOGLE_APPLICATION_CREDENTIALS={{ restic_repos[item.repo].google_application_credentials }}
+{% endif %}
 {% if restic_repos[item.repo].aws_access_key is defined %}
 export AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
 {% endif %}


### PR DESCRIPTION
This pull request introduces enhancements to the `templates/restic_access_Linux.j2` and `templates/restic_script_Linux.j2` files, adding support for Google Cloud credentials.

Enhancements for Google Cloud support:

* [`templates/restic_access_Linux.j2`](diffhunk://#diff-f03ae9e0c089c7916a606e429b5ef3cda538acae7935bf6a0abdb71cb0f682bbR8-R13): Added conditional exports for `GOOGLE_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS` if they are defined in the repository configuration.
* [`templates/restic_script_Linux.j2`](diffhunk://#diff-47b77a83a5538113db223d4a906db21f71f48d6a3d251fba3a97daf49a915742R57-R62): Similarly, added conditional exports for `GOOGLE_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS` to support Google Cloud credentials.