### PR TITLE
Rename past_backup_cmd to post_backup_cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Available variables:
 | `stdin_cmd`        | no (yes if `stdin` == `true`) | The command to produce the stdin. |
 | `stdin_filename`   |              no               | The filename used in the repository. |
 | `pre_backup_cmd`   |              no               | A command to run before backup, typically used to dump databases to disk |
-| `past_backup_cmd`   |              no               | A command to run after backup, typically used to cleanup database dumps on disk |
+| `post_backup_cmd`   |              no               | A command to run after backup, typically used to cleanup database dumps on disk |
 | `tags`             |              no               | Array of default tags  |
 | `keep_last`        |              no               | If set, only keeps the last n snapshots.  |
 | `keep_hourly`      |              no               | If set, only keeps the last n hourly snapshots.                                                                                                                              |

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -27,18 +27,18 @@ fi
 {% set pre_backup_cmd_result_log, pre_backup_cmd_output_log = "/dev/null", "/dev/null" %}
 {% set backup_result_log, backup_output_log = "/dev/null", "/dev/null" %}
 {% set forget_result_log, forget_output_log = "/dev/null", "/dev/null" %}
-{% set past_backup_cmd_result_log, past_backup_cmd_output_log = "/dev/null", "/dev/null" %}
+{% set post_backup_cmd_result_log, post_backup_cmd_output_log = "/dev/null", "/dev/null" %}
 {% else %}
 {% if (item.log_to_journald is defined and item.log_to_journald) %}
 {% set pre_backup_cmd_result_log, pre_backup_cmd_output_log = "| systemd-cat -t " + item.name, "2>&1 | systemd-cat -t " + item.name %}
 {% set backup_result_log, backup_output_log = "| systemd-cat -t " + item.name, "2>&1 | systemd-cat -t " + item.name %}
 {% set forget_result_log, forget_output_log = "| systemd-cat -t " + item.name, "2>&1 | systemd-cat -t " + item.name %}
-{% set past_backup_cmd_result_log, past_backup_cmd_output_log = "| systemd-cat -t " + item.name, "2>&1 | systemd-cat -t " + item.name %}
+{% set post_backup_cmd_result_log, post_backup_cmd_output_log = "| systemd-cat -t " + item.name, "2>&1 | systemd-cat -t " + item.name %}
 {% else %}
 {% set pre_backup_cmd_result_log, pre_backup_cmd_output_log = ">> " + restic_log_dir + "/" + item.name + "-pre_backup_cmd-result.log", "| tee " + restic_log_dir + "/" + item.name + "-pre_backup_cmd-output.log" %}
 {% set backup_result_log, backup_output_log = ">> " + restic_log_dir + "/" + item.name + "-backup-result.log", "| tee " + restic_log_dir + "/" + item.name + "-backup-output.log" %}
 {% set forget_result_log, forget_output_log = ">> " + restic_log_dir + "/" + item.name + "-forget-result.log", "| tee " + restic_log_dir + "/" + item.name + "-forget-output.log" %}
-{% set past_backup_cmd_result_log, past_backup_cmd_output_log = ">> " + restic_log_dir + "/" + item.name + "-past_backup_cmd-result.log", "| tee " + restic_log_dir + "/" + item.name + "-past_backup_cmd-output.log" %}
+{% set post_backup_cmd_result_log, post_backup_cmd_output_log = ">> " + restic_log_dir + "/" + item.name + "-post_backup_cmd-result.log", "| tee " + restic_log_dir + "/" + item.name + "-post_backup_cmd-output.log" %}
 {% endif %}
 {% endif %}
 
@@ -326,13 +326,20 @@ else
     {% endif %}
 fi
 
+{# 
+  post_backup_cmd was previously named past_backup_cmd, 
+  to not break configs still using that spelling 
+  we make sure both new and old spelling works
+#}
 {% if item.past_backup_cmd is defined %}
-  {{ item.past_backup_cmd }} {{ past_backup_cmd_output_log }}
+  {{ item.past_backup_cmd }} {{ post_backup_cmd_output_log }}
+{% if item.post_backup_cmd is defined %}
+  {{ item.post_backup_cmd }} {{ post_backup_cmd_output_log }}
 if [[ $? -eq 0 ]]
 then
-    echo "$(date -u '+%Y-%m-%d %H:%M:%S') OK" {{ past_backup_cmd_result_log }}
+    echo "$(date -u '+%Y-%m-%d %H:%M:%S') OK" {{ post_backup_cmd_result_log }}
 else
-    echo "$(date -u '+%Y-%m-%d %H:%M:%S') ERROR" {{ past_backup_cmd_result_log }}
+    echo "$(date -u '+%Y-%m-%d %H:%M:%S') ERROR" {{ post_backup_cmd_result_log }}
     {% if item.mail_on_error is defined and item.mail_on_error == true %}
     mail -s "restic backup failed on {{ ansible_hostname }}" {{ item.mail_address }}  <<< "Something went wrong while running restic backup script running at {{ ansible_hostname }} at $(date -u '+%Y-%m-%d %H:%M:%S').
       {%- if item.src is defined -%}


### PR DESCRIPTION
Minor, but `past_backup_cmd` looks like a typo.

It should probably be `post_backup_cmd`, using the post-prefix: https://en.wiktionary.org/wiki/post-#English

Since the Ansible yaml config gladly accepts non-existing keys without complaining a user might type the more expected `post_`-prefixed variant and run into trouble.

I suggest we rename the attribute. My patch still ensures the old name works which should make this a non-breaking change.