### PR TITLE
Change default cron to `0 2 * * *`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Available variables:
 | `forget_extra_args` |       no                     | Extra arguments to pass to the `restic forget` command. |
 | `scheduled`        |         no (`false`)          | If `restic_create_schedule` is set to `true`, this backup is scheduled and tries to create a systemd timer unit. If it fails, it is creating a cronjob. |
 | `schedule_oncalendar` |  ``'*-*-* 02:00:00'``      | The time for the systemd timer. Please notice the randomDelaySec option. By Default the backup is done every night at 2 am (+0-4h). But only if scheduled is true.  |
-| `schedule_minute`  |           no (`*`)            | Minute when the job is run. ( 0-59, *, */2, etc ) |
+| `schedule_minute`  |           no (`0`)            | Minute when the job is run. ( 0-59, *, */2, etc ) |
 | `schedule_hour`    |           no (`2`)            | Hour when the job is run. ( 0-23, *, */2, etc )  |
 | `schedule_weekday` |           no (`*`)            | Weekday when the job is run.  ( 0-6 for Sunday-Saturday, *, etc ) |
 | `schedule_month`   |           no (`*`)            | Month when the job is run. ( 1-12, *, */2, etc )  |

--- a/tasks/delete_legacy_cron_entry.yml
+++ b/tasks/delete_legacy_cron_entry.yml
@@ -17,7 +17,7 @@
   ansible.builtin.cron:
     name: "do1jlr.restic backup {{ item.name }}"
     job: "CRON=true {{ restic_script_dir }}/backup-{{ item.name | replace(' ', '') }}.sh"
-    minute: '{{ item.schedule_minute | default("*") }}'
+    minute: '{{ item.schedule_minute | default("0") }}'
     hour: '{{ item.schedule_hour | default("2") }}'
     weekday: '{{ item.schedule_weekday | default("*") }}'
     month: '{{ item.schedule_month | default("*") }}'

--- a/tasks/restic_create_cron.yml
+++ b/tasks/restic_create_cron.yml
@@ -3,7 +3,7 @@
   ansible.builtin.cron:
     name: "do1jlr.restic backup {{ item.name }}"
     job: "CRON=true {{ restic_script_dir }}/backup-{{ item.name | replace(' ', '') }}.sh"
-    minute: '{{ item.schedule_minute | default("*") }}'
+    minute: '{{ item.schedule_minute | default("0") }}'
     hour: '{{ item.schedule_hour | default("2") }}'
     weekday: '{{ item.schedule_weekday | default("*") }}'
     month: '{{ item.schedule_month | default("*") }}'

--- a/tasks/restic_delete_cron.yml
+++ b/tasks/restic_delete_cron.yml
@@ -3,7 +3,7 @@
   ansible.builtin.cron:
     name: "do1jlr.restic backup {{ item.name }}"
     job: "CRON=true {{ restic_script_dir }}/backup-{{ item.name | replace(' ', '') }}.sh"
-    minute: '{{ item.schedule_minute | default("*") }}'
+    minute: '{{ item.schedule_minute | default("0") }}'
     hour: '{{ item.schedule_hour | default("2") }}'
     weekday: '{{ item.schedule_weekday | default("*") }}'
     month: '{{ item.schedule_month | default("*") }}'


### PR DESCRIPTION
This means "at 2am" and matches the default systemd schedule_oncalendar. Previously it was `* 2 * * *` which meant "At every minute past hour 2" and probably was not intended.

Fixes: #139