### PR TITLE
fix unsafe attribute access in j2 template, fixes #142

### DIFF
--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -89,8 +89,7 @@ export B2_ACCOUNT_KEY={{ restic_repos[item.repo].b2_account_key }}
 {% endif %}
 {% if item.src is defined  and item.src is string %}
 BACKUP_SOURCE={{ item.src }}
-{% endif %}
-{% if item.src is defined  and item.src.__class__.__name__ =='list' %}
+{% elif item.src is defined and item.src is sequence %}
 BACKUP_SOURCE='{{ item.src| join(' ') }}'
 {% endif %}
 


### PR DESCRIPTION
Ansible 2.19 introduces some kind of security feature that prohibits accessing certain attributes.

We're using some of those attributes to check whether src is a list. There seems to be a different way of doing that by using `is sequence`.

With the following role invocation:

```yaml
---
- hosts: testing
  roles:
    - ansible_role_restic
  vars:
    restic_create_schedule: false
    restic_repos:
      local:
        location: '/mnt/backup'
        password: 'ChangM3'
        init: true
    restic_backups:
      single:
        name: single
        repo: local
        src: /home/single
        scheduled: false
      multiple:
        name: multiple
        repo: local
        src:
          - /home/test
          - /home/test2
        scheduled: false
```

The resulting scripts are the same as they were before:

```shell
root@provisioning:/opt/restic# cat backup-{single,multiple}.sh | grep BACKUP_SOURCE=
BACKUP_SOURCE=/home/single
BACKUP_SOURCE='/home/test /home/test2'
```