### PR TITLE
Run without requiring root

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,8 +14,9 @@ restic_backup_now: false
 # restic_schedule_type: "cronjob"
 restic_no_log: true
 
-restic_dir_owner: '{{ ansible_user | default(ansible_user_id) }}'
-restic_dir_group: '{{ ansible_user | default(ansible_user_id) }}'
+restic_user: restic
+restic_dir_owner: '{{ restic_user }}'
+restic_dir_group: '{{ restic_user }}'
 
 # timer defaults
 restic_systemd_timer_randomizeddelaysec: '4h'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,12 +24,6 @@
         owner: '{{ restic_dir_owner }}'
         group: '{{ restic_dir_group }}'
 
-    - name: ensure log folder exists and is writeable
-      ansible.builtin.file:
-        path: "{{ restic_log_dir }}"
-        owner: '{{ restic_user }}'
-        group: '{{ restic_user }}'
-        mode: '0755'
       
     - name: Ensure restic binary has cap_dac_read_search capability
       community.general.capabilities:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,9 +19,23 @@
     - name: (INSTALL) Ensure permissions are correct
       ansible.builtin.file:
         path: '{{ restic_download_path }}/bin/restic-{{ restic_version }}'
-        mode: '0755'
+        # no executable rights for any user because restic now can read any file
+        mode: '0750'
         owner: '{{ restic_dir_owner }}'
         group: '{{ restic_dir_group }}'
+
+    - name: ensure log folder exists and is writeable
+      ansible.builtin.file:
+        path: "{{ restic_log_dir }}"
+        owner: '{{ restic_user }}'
+        group: '{{ restic_user }}'
+        mode: '0755'
+      
+    - name: Ensure restic binary has cap_dac_read_search capability
+      community.general.capabilities:
+        path: "/opt/restic/bin/restic-{{ restic_version }}"
+        capability: cap_dac_read_search=+ep
+        state: present
 
     - name: (INSTALL) Test the binary
       ansible.builtin.command: "{{ restic_bin_path }} version"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,9 @@
     distribution_version: '{{ ansible_distribution_version }}'
     distribution_major_version: '{{ ansible_distribution_major_version }}'
 
+- name: Set user permissions on folders
+  ansible.builtin.include_tasks: 'permissions.yml'
+
 - name: Run backups now
   ansible.builtin.include_tasks: 'run_backup.yml'
   when: restic_backup_now | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,9 @@
   ansible.builtin.include_tasks: 'versioncheck.yml'
   when: submodules_versioncheck | bool
 
+- name: Add restic user
+  ansible.builtin.include_tasks: 'user.yml'
+
 - name: Make sure restic is available
   ansible.builtin.include_tasks: 'preparation.yml'
 

--- a/tasks/permissions.yml
+++ b/tasks/permissions.yml
@@ -1,0 +1,22 @@
+- name: ensure log folder exists and is writeable
+  ansible.builtin.file:
+    path: "{{ restic_log_dir }}"
+    owner: '{{ restic_user }}'
+    group: '{{ restic_user }}'
+    mode: '0755'
+- name: ensure cache dir exists and is writeable
+  ansible.builtin.file:
+    path: "{{ restic_log_dir }}"
+    owner: '{{ restic_user }}'
+    group: '{{ restic_user }}'
+    mode: '0750'
+- name: Set ownership recursively
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ restic_user }}"
+    group: "{{ restic_user }}"
+    recurse: true
+  with_items:
+  - "{{ restic_log_dir }}"
+  - "{{ restic_cache_dir }}"

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,0 +1,6 @@
+- name: create restic user
+  user:
+    name: "{{ restic_user }}"
+    shell: "/sbin/nologin"
+    system: true
+

--- a/templates/restic.service.j2
+++ b/templates/restic.service.j2
@@ -16,4 +16,5 @@ ExecStart=/usr/bin/nice -n {{ item.niceness }} {{ restic_script_dir }}/backup-{{
 ExecStart={{ restic_script_dir }}/backup-{{ item.name }}.sh
 {% endif %}
 TimeoutStartSec=0
+User={{ restic_user }}
 Environment="CRON=true"


### PR DESCRIPTION
This implements running restic using a non-root account, as mentioned under https://restic.readthedocs.io/en/stable/080_examples.html#backing-up-your-system-without-running-restic-as-root

Feel free to give feedback, eg if this should be behind a switch, but this implementation worked at least for our test-cases.