### PR TITLE
fix: correct restic__cache_dir variable in permissions task

### DIFF
--- a/tasks/permissions.yml
+++ b/tasks/permissions.yml
@@ -3,17 +3,17 @@
   become: true
   ansible.builtin.file:
     path: "{{ restic_log_dir }}"
-    owner: '{{ restic_user }}'
-    group: '{{ restic_user }}'
-    mode: '0755'
+    owner: "{{ restic_user }}"
+    group: "{{ restic_user }}"
+    mode: "0755"
 
 - name: Ensure cache dir exists and is writeable
   become: true
   ansible.builtin.file:
-    path: "{{ restic_log_dir }}"
-    owner: '{{ restic_user }}'
-    group: '{{ restic_user }}'
-    mode: '0750'
+    path: "{{ restic__cache_dir }}"
+    owner: "{{ restic_user }}"
+    group: "{{ restic_user }}"
+    mode: "0750"
 
 - name: Set ownership recursively
   become: true
@@ -25,4 +25,4 @@
     recurse: true
   with_items:
     - "{{ restic_log_dir }}"
-    - "{{ restic_cache_dir }}"
+    - "{{ restic__cache_dir }}"


### PR DESCRIPTION
The variable is defined as `restic__cache_dir` (with a double underscore).  
In `tasks/permissions.yml` it was mistakenly referenced with a single underscore (`restic_cache_dir`).  
This PR fixes the variable name mismatch so the cache directory permissions are applied correctly.
