### PR TITLE
Backup script template loop fix

### DIFF
--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -330,10 +330,12 @@ fi
   to not break configs still using that spelling 
   we make sure both new and old spelling works
 #}
-{% if item.past_backup_cmd is defined %}
-  {{ item.past_backup_cmd }} {{ post_backup_cmd_output_log }}
-{% if item.post_backup_cmd is defined %}
-  {{ item.post_backup_cmd }} {{ post_backup_cmd_output_log }}
+{% if item.past_backup_cmd is defined or item.post_backup_cmd is defined %}
+  {% if item.past_backup_cmd is defined %}
+    {{ item.past_backup_cmd }} {{ post_backup_cmd_output_log }}
+  {% else %}
+    {{ item.post_backup_cmd }} {{ post_backup_cmd_output_log }}
+  {% endif %}
 if [[ $? -eq 0 ]]
 then
     echo "$(date -u '+%Y-%m-%d %H:%M:%S') OK" {{ post_backup_cmd_result_log }}


### PR DESCRIPTION
Fixes missing close loop in the backup script template:

`TASK [do1jlr.restic : (BACKUP) Create backup script] *************************************************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: . Unexpected end of template. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.`

While catering for both past and post backup commands the new if block wasn't properly closed