### PR TITLE
Make restic forget optional on repo level

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Available variables:
 | `keep_tag`         |              no               | If set, keep snapshots with this tags. Make sure to specify a list.                                                                                                          |
 | `prune`            |         no (`false`)          | If `true`, the `restic forget` command in the script has the [`--prune` option](https://restic.readthedocs.io/en/stable/060_forget.html#removing-backup-snapshots) appended. |
 | `forget_extra_args` |       no                     | Extra arguments to pass to the `restic forget` command. |
+| `skip_forget`      |         no                    | Skip restic forget, eg if you have a separate cleanup script. |
 | `scheduled`        |         no (`false`)          | If `restic_create_schedule` is set to `true`, this backup is scheduled and tries to create a systemd timer unit. If it fails, it is creating a cronjob. |
 | `schedule_oncalendar` |  ``'*-*-* 02:00:00'``      | The time for the systemd timer. Please notice the randomDelaySec option. By Default the backup is done every night at 2 am (+0-4h). But only if scheduled is true.  |
 | `schedule_minute`  |           no (`0`)            | Minute when the job is run. ( 0-59, *, */2, etc ) |

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -330,10 +330,12 @@ fi
   to not break configs still using that spelling 
   we make sure both new and old spelling works
 #}
-{% if item.past_backup_cmd is defined %}
-  {{ item.past_backup_cmd }} {{ post_backup_cmd_output_log }}
-{% if item.post_backup_cmd is defined %}
-  {{ item.post_backup_cmd }} {{ post_backup_cmd_output_log }}
+{% if item.past_backup_cmd is defined or item.post_backup_cmd is defined %}
+  {% if item.past_backup_cmd is defined %}
+    {{ item.past_backup_cmd }} {{ post_backup_cmd_output_log }}
+  {% else %}
+    {{ item.post_backup_cmd }} {{ post_backup_cmd_output_log }}
+  {% endif %}
 if [[ $? -eq 0 ]]
 then
     echo "$(date -u '+%Y-%m-%d %H:%M:%S') OK" {{ post_backup_cmd_result_log }}


### PR DESCRIPTION
Adds an option to skip running restic forget. Closes #157 

I also included #152 because without it the role would already fail.