### PR TITLE
fix: only change user when default user is set

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
 
 - name: Add restic user
   ansible.builtin.include_tasks: 'user.yml'
+  when: restic_user == 'restic'
 
 - name: Make sure restic is available
   ansible.builtin.include_tasks: 'preparation.yml'


### PR DESCRIPTION
This may require more testing - it's bit of a break-fix change.

Introduced in #145 

Example:

I had a host where it would make sense to run restic as root - running the role changed the root shell to `/sbin/nologin`.

This would also affect anyone running restic as their own user or a user that already exists where the shell should not be `/sbin/nologin`.