### PR TITLE
#88 Improve restic bash script to assert whether the pid process is stale 

### DIFF
--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -8,7 +8,12 @@ trap "rm -f $pid" SIGSEGV
 trap "rm -f $pid" SIGINT
 
 if [ -e $pid ]; then
-  echo "Another version of this restic backup script is already running!"
+  # Read the PID from the file
+  OLD_PID=$(cat "$pid")
+
+  # Check if the process is actually running
+  if ps -p "$OLD_PID" > /dev/null 2>&1; then
+    echo "Another version of this restic backup script is already running! (PID: $OLD_PID)"
    {% if item.mail_on_error is defined and item.mail_on_error == true %}
     mail -s "starting restic backup failed on {{ ansible_facts['hostname'] }}" {{ item.mail_address }}  <<< "Another restic backup process is already running. We canceled starting a new restic backup script running at {{ ansible_facts['hostname'] }} at $(date -u '+%Y-%m-%d %H:%M:%S').
       {%- if item.src is defined -%}
@@ -16,7 +21,10 @@ if [ -e $pid ]; then
       {%- endif -%}
       {{ ' ' }}Please repair the restic-{{ item.name | replace(' ', '') }} job."
     {% endif %}
-   exit # pid file exists, another instance is running, so now we politely exit
+    exit 1
+  else
+    echo "Warning: Stale PID file found. (process $OLD_PID is not running). Proceeding with execution" >&2
+  fi
 else
     echo $$ > $pid # pid file doesn't exit, create one and go on
 fi


### PR DESCRIPTION
Relates to #88

These changes prevent a false-positive of overlapping process runs:
> Another version of this restic backup script is already running
under the conditions where the process id within the pid file does not actually exist. i.e. where process was ungracefully terminated without SIGTERM/SIGINT

tl;dr these changes:
- confirm that the process based on the pid file contents **actually** exists
   - if process exists, it is the same behaviour as before - echo & mail (if enabled) + but I've also added in exit code 1 (to indicate a sort of error/failure)
   - if process does _not_ exist, echo a warning (to stdout) "Warning: Stale PID file found ...." but allow the script to run as normal