### PR TITLE
Use same folder for access/backup cache

### DIFF
--- a/templates/restic_access_Linux.j2
+++ b/templates/restic_access_Linux.j2
@@ -43,5 +43,5 @@ BACKUP_NAME={{ item.name }}
 BACKUP_SOURCE={{ item.src }}
 {% endif %}
 {% if restic__cache_config | bool -%}
-  export XDG_CACHE_HOME={{ restic__cache_dir }}
+  export RESTIC_CACHE_DIR={{ restic__cache_dir }}
 {% endif %}

--- a/templates/restic_access_Linux.j2
+++ b/templates/restic_access_Linux.j2
@@ -42,3 +42,6 @@ BACKUP_NAME={{ item.name }}
 {% if item.src is defined %}
 BACKUP_SOURCE={{ item.src }}
 {% endif %}
+{% if restic__cache_config | bool -%}
+  export XDG_CACHE_HOME={{ restic__cache_dir }}
+{% endif %}

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -43,7 +43,7 @@ fi
 {% endif %}
 
 {% if restic__cache_config | bool -%}
-  export XDG_CACHE_HOME={{ restic__cache_dir }}
+  export RESTIC_CACHE_DIR={{ restic__cache_dir }}
 {% endif %}
 
 {% if restic__limit_cpu_usage | bool -%}


### PR DESCRIPTION
My goal was using the same folder for caching when using access than when using backup.

But a word of warning:
if `XDG_CACHE_HOME` was used, the restic cache would actually end up under `{{restic__cache_dir}}/restic` .
Setting `XDG_CACHE_HOME` in access.* seems like a bad idea, because this would affect other applications than restic.

It seems a better idea to use `RESTIC_CACHE_DIR` variable ( https://restic.readthedocs.io/en/stable/manual_rest.html#caching ). However, if we use this, the cache will end up under `{{ restic__cache_dir }}` (without subdir).

So in order to be 'backwards compatible', we could also choose to just append /restic again when setting the variable. But maybe it is better to just change it? 